### PR TITLE
update docker image references to live tags

### DIFF
--- a/2.2.0/docker-compose.yml
+++ b/2.2.0/docker-compose.yml
@@ -3,13 +3,13 @@ version: "3.9"
 services:
 
   zeo:
-    image: senaite-latest
+    image: senaite/senaite:edge
     command: zeo
     volumes:
       - ./data:/data
 
   instance1:
-    image: senaite-latest
+    image: senaite/senaite:edge
     ports:
       - 8081:8080
     links:
@@ -23,7 +23,7 @@ services:
       ZEO_ADDRESS: "zeo:8080"
 
   instance2:
-    image: senaite-latest
+    image: senaite/senaite:edge
     ports:
       - 8082:8080
     links:

--- a/2.2.0/docker-compose.yml
+++ b/2.2.0/docker-compose.yml
@@ -3,13 +3,13 @@ version: "3.9"
 services:
 
   zeo:
-    image: senaite/senaite:edge
+    image: senaite/senaite:2.2.0
     command: zeo
     volumes:
       - ./data:/data
 
   instance1:
-    image: senaite/senaite:edge
+    image: senaite/senaite:2.2.0
     ports:
       - 8081:8080
     links:
@@ -23,7 +23,7 @@ services:
       ZEO_ADDRESS: "zeo:8080"
 
   instance2:
-    image: senaite/senaite:edge
+    image: senaite/senaite:2.2.0
     ports:
       - 8082:8080
     links:

--- a/2.3.0/docker-compose.yml
+++ b/2.3.0/docker-compose.yml
@@ -3,13 +3,13 @@ version: "3.9"
 services:
 
   zeo:
-    image: senaite-latest
+    image: senaite/senaite:edge
     command: zeo
     volumes:
       - ./data:/data
 
   instance1:
-    image: senaite-latest
+    image: senaite/senaite:edge
     ports:
       - 8081:8080
     links:
@@ -23,7 +23,7 @@ services:
       ZEO_ADDRESS: "zeo:8080"
 
   instance2:
-    image: senaite-latest
+    image: senaite/senaite:edge
     ports:
       - 8082:8080
     links:

--- a/2.3.0/docker-compose.yml
+++ b/2.3.0/docker-compose.yml
@@ -3,13 +3,13 @@ version: "3.9"
 services:
 
   zeo:
-    image: senaite/senaite:edge
+    image: senaite/senaite:2.3.0
     command: zeo
     volumes:
       - ./data:/data
 
   instance1:
-    image: senaite/senaite:edge
+    image: senaite/senaite:2.3.0
     ports:
       - 8081:8080
     links:
@@ -23,7 +23,7 @@ services:
       ZEO_ADDRESS: "zeo:8080"
 
   instance2:
-    image: senaite/senaite:edge
+    image: senaite/senaite:2.3.0
     ports:
       - 8082:8080
     links:

--- a/latest/docker-compose.yml
+++ b/latest/docker-compose.yml
@@ -3,13 +3,13 @@ version: "3.9"
 services:
 
   zeo:
-    image: senaite-latest
+    image: senaite/senaite:edge
     command: zeo
     volumes:
       - ./data:/data
 
   instance1:
-    image: senaite-latest
+    image: senaite/senaite:edge
     ports:
       - 8081:8080
     links:
@@ -23,7 +23,7 @@ services:
       ZEO_ADDRESS: "zeo:8080"
 
   instance2:
-    image: senaite-latest
+    image: senaite/senaite:edge
     ports:
       - 8082:8080
     links:


### PR DESCRIPTION
Hi @ramonski

refs #16 - the issue was raised because it seem like the default docker-compose.yml should reference a working dockerhub image tag

This patch provides that -

Regards, 
Bernie