### PR TITLE
Fix archive repositories

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -31,8 +31,11 @@ COPY requirements.txt buildout.cfg $SENAITE_INSTANCE_HOME/
 COPY build_deps.txt run_deps.txt docker-initialize.py docker-entrypoint.sh /
 
 # Note: we concatenate all commands to avoid multiple layer generation and reduce the image size
-RUN sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list && \
-    sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list && \
+RUN echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99no-check-valid-until && \
+    sed -i 's|http://deb.debian.org|http://archive.debian.org|g' /etc/apt/sources.list && \
+    sed -i 's|http://security.debian.org|http://archive.debian.org|g' /etc/apt/sources.list && \
+    sed -i '/stretch-updates/d' /etc/apt/sources.list && \
+    sed -i '/buster-updates/d' /etc/apt/sources.list && \
     apt-get update \
     # Install system packages
     && apt-get install -y --no-install-recommends $(grep -vE "^\s*#" /build_deps.txt | tr "\n" " ") \


### PR DESCRIPTION
This PR fixes the Debian archive repository URLs that caused the following build failure:

```
Error: buildx failed with: ERROR: failed to build: failed to solve: process "/bin/sh -c sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list &&     sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list &&     apt-get update     && apt-get install -y --no-install-recommends $(grep -vE \"^\\s*#\" /build_deps.txt | tr \"\\n\" \" \")     && apt-get install -y --no-install-recommends $(grep -vE \"^\\s*#\" /run_deps.txt | tr \"\\n\" \" \")     && wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/$PLONE_UNIFIED_INSTALLER.tgz     && echo \"$PLONE_MD5 Plone.tgz\" | md5sum -c -     && tar -xzf /Plone.tgz     && cp -rv $PLONE_UNIFIED_INSTALLER/base_skeleton/* $SENAITE_INSTANCE_HOME     && cp -v $PLONE_UNIFIED_INSTALLER/buildout_templates/buildout.cfg $SENAITE_INSTANCE_HOME/buildout-base.cfg     && rm -rf $PLONE_UNIFIED_INSTALLER Plone.tgz     && cd $SENAITE_INSTANCE_HOME     && pip install -r requirements.txt     && buildout     && ln -s $SENAITE_FILESTORAGE/ var/filestorage     && ln -s $SENAITE_BLOBSTORAGE/ var/blobstorage     && chown -R senaite:senaite $SENAITE_HOME $SENAITE_DATA     && apt-get purge -y --auto-remove $(grep -vE \"^\\s*#\" /build_deps.txt  | tr \"\\n\" \" \")     && rm -rf /$SENAITE_HOME/buildout-cache     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 8
```