### PR TITLE
Fix image build: skip expired launchpad TLS cert on installer download

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -41,7 +41,10 @@ RUN echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99no-chec
     && apt-get install -y --no-install-recommends $(grep -vE "^\s*#" /build_deps.txt | tr "\n" " ") \
     && apt-get install -y --no-install-recommends $(grep -vE "^\s*#" /run_deps.txt | tr "\n" " ") \
     # Fetch unified installer
-    && wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/$PLONE_UNIFIED_INSTALLER.tgz \
+    # buster's CA bundle is EOL and no longer trusts launchpad's TLS
+    # chain, so skip the cert check; the MD5 verification below still
+    # guarantees the integrity of the downloaded archive
+    && wget --no-check-certificate -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/$PLONE_UNIFIED_INSTALLER.tgz \
     && echo "$PLONE_MD5 Plone.tgz" | md5sum -c - \
     && tar -xzf /Plone.tgz \
     && cp -rv $PLONE_UNIFIED_INSTALLER/base_skeleton/* $SENAITE_INSTANCE_HOME \


### PR DESCRIPTION
## What

The `Build new docker image` workflow started failing when building the `latest` image (`senaite/senaite:edge`, `senaite/senaite:2.x`).

The build dies while downloading the Plone unified installer:

    ERROR: The certificate of 'launchpadlibrarian.net' is not trusted.
    ERROR: The certificate of 'launchpadlibrarian.net' has expired.

## Why

The base image is `python:2.7-slim-buster`. Debian buster is EOL and its `ca-certificates` bundle no longer trusts launchpad's current TLS chain, so `wget` refuses the download. This is the same class of EOL breakage the Dockerfile already works around for apt (archive.debian.org rewrite, `Check-Valid-Until "false"`).

## Fix

Pass `--no-check-certificate` to the single `wget` that fetches the installer. Integrity is unaffected: the very next line verifies the exact `$PLONE_MD5` of the downloaded archive, so a tampered or corrupt file is still rejected.

Only `latest/Dockerfile` is touched, which is what the failing runner builds.