### PR TITLE
Track senaite.ldap 2.x branch

### DIFF
--- a/latest/buildout.cfg
+++ b/latest/buildout.cfg
@@ -40,7 +40,7 @@ senaite.lims = git https://github.com/senaite/senaite.lims.git branch=2.x
 senaite.databox = git https://github.com/senaite/senaite.databox.git branch=master
 senaite.storage = git https://github.com/senaite/senaite.storage.git branch=2.x
 senaite.patient = git https://github.com/senaite/senaite.patient.git branch=master
-senaite.ldap = git https://github.com/senaite/senaite.ldap.git branch=master
+senaite.ldap = git https://github.com/senaite/senaite.ldap.git branch=2.x
 
 [client1]
 recipe =


### PR DESCRIPTION
senaite.ldap released 2.0.0, cut from its new `2.x` branch. The image build still pinned `senaite.ldap` to `branch=master`, which is the stale 1.x line ("Stamp 1.1.0 release date"), so the built image pulled senaite.ldap 1.1.0 instead of 2.0.0.

This switches the source pin to `branch=2.x`, aligning senaite.ldap with every other package in the buildout (core, lims, impress, storage, …) that already tracks its `2.x` line. The image now builds senaite.ldap 2.0.0 and follows the 2.1.0.dev line going forward.

The repo default branch has also been changed to `2.x` so new clones and PRs target the active line.