### PR TITLE
Pin plone.jsonapi.core to 0.8.0 in the latest image build

### DIFF
--- a/latest/buildout.cfg
+++ b/latest/buildout.cfg
@@ -4,6 +4,13 @@ extends =
   buildout-base.cfg
 extensions = mr.developer
 
+# plone.jsonapi.core 0.8.0 ships on PyPI under the PEP 625 normalized
+# sdist name (plone_jsonapi_core-0.8.0.tar.gz), which this py2.7 buildout
+# cannot match. Pull the legacy dotted-name sdist attached to the GitHub
+# release instead, and pin the version below.
+find-links +=
+    https://github.com/collective/plone.jsonapi.core/releases/download/0.8.0/plone.jsonapi.core-0.8.0.tar.gz
+
 var-dir=/data
 user=admin:admin
 
@@ -75,3 +82,4 @@ enabled = False
 [versions]
 setuptools =
 zc.buildout =
+plone.jsonapi.core = 0.8.0


### PR DESCRIPTION
## What

Bakes `plone.jsonapi.core` 0.8.0 into the `latest` image by adding a find-links to the GitHub-release sdist and pinning the version in `[versions]`.

## Why

0.8.0 publishes its sdist on PyPI under the PEP 625 normalized name (`plone_jsonapi_core-0.8.0.tar.gz`). The py2.7 buildout / zc.buildout in this image cannot match the normalized name, so without this change the build silently falls back to the last dotted-name release on PyPI (0.7.0).

The 0.8.0 GitHub release carries a legacy dotted-name copy of the sdist (`plone.jsonapi.core-0.8.0.tar.gz`) precisely so old buildouts can resolve it via find-links. This mirrors the approach already used for senaite.ldap.

## Changes (`latest/buildout.cfg`)

- `find-links +=` https://github.com/collective/plone.jsonapi.core/releases/download/0.8.0/plone.jsonapi.core-0.8.0.tar.gz
- `[versions]` `plone.jsonapi.core = 0.8.0`

## Verification

- Release asset is publicly downloadable (302 → 200, served as `plone.jsonapi.core-0.8.0.tar.gz`).
- 0.8.0 is backward compatible with senaite.jsonapi (no API removals; new declarative-permission feature is opt-in).